### PR TITLE
fix: improve Fisher installation compatibility for auto-switch feature

### DIFF
--- a/fish/functions/wkit.fish
+++ b/fish/functions/wkit.fish
@@ -146,13 +146,14 @@ function wkit-add-auto -d "Add worktree with optional auto-switch"
     echo "$wkit_output"
     
     if test $exit_code -eq 0
-        # Check if the last line is a path (auto-switch output)
-        set -l last_line (echo "$wkit_output" | tail -n 1)
+        # Extract the last word which should be the path
+        set -l words (echo "$wkit_output" | string split ' ')
+        set -l potential_path $words[-1]
         
-        # If last line looks like a path, switch to it
-        if test -d "$last_line"
-            cd "$last_line"
-            echo "✓ Automatically switched to: "(basename "$last_line")" at $last_line"
+        # If the last word looks like a path, switch to it
+        if test -d "$potential_path"
+            cd "$potential_path"
+            echo "✓ Automatically switched to: "(basename "$potential_path")" at $potential_path"
         end
     end
     


### PR DESCRIPTION
## Summary
- Fix `wkit-add-auto` function to properly extract worktree path from output
- Handle single-line output format correctly using `string split` instead of line-based parsing
- Ensure auto-switch functionality works reliably with Fisher installations

## Problem
The original implementation used `tail -n 1` to extract the path from `wkit add` output, but the actual output was formatted as a single line without proper line breaks, causing the path extraction to fail.

## Solution
- Changed from line-based parsing to word-based parsing
- Extract the last word from output which contains the worktree path
- Maintain compatibility with existing functionality

## Test plan
- [x] Manual testing: `wkit-add test-branch` automatically switches directory
- [x] Verified with Fisher installation from local path
- [x] Confirmed working with updated binary that includes `--no-switch` flag

## Related
- Completes the auto-switch feature from issue #12
- Ensures Fisher users get the full auto-switch experience

🤖 Generated with [Claude Code](https://claude.ai/code)