### PR TITLE
change: worktreeのデフォルトパスを.git/.wkit-worktreesに変更

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ impl Default for CopyFiles {
 }
 
 fn default_worktree_path() -> String {
-    ".wkit-worktrees".to_string()
+    ".git/.wkit-worktrees".to_string()
 }
 
 fn default_sync_strategy() -> String {
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = Config::default();
-        assert_eq!(config.default_worktree_path, ".wkit-worktrees");
+        assert_eq!(config.default_worktree_path, ".git/.wkit-worktrees");
         assert!(!config.auto_cleanup);
         assert!(config.z_integration);
     }
@@ -203,7 +203,7 @@ mod tests {
     fn test_resolve_worktree_path_with_default_relative() {
         let config = Config::default();
         let result = config.resolve_worktree_path("feature", None);
-        assert_eq!(result, ".wkit-worktrees/feature");
+        assert_eq!(result, ".git/.wkit-worktrees/feature");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- worktreeのデフォルト作成場所を`.wkit-worktrees`から`.git/.wkit-worktrees`に変更
- `.git`ディレクトリ配下に作成することで自動的に`.gitignore`対象となる
- テストケースも新しいパスに対応するよう更新

## Test plan
- [x] 既存のユニットテストがすべて通ることを確認
- [x] 統合テストも実行して問題ないことを確認
- [x] 実際にworktreeを作成して`.git/.wkit-worktrees`に作成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)