### PR TITLE
feat: add remote branch checkout command for worktree creation

### DIFF
--- a/fish/functions/wkit.fish
+++ b/fish/functions/wkit.fish
@@ -160,10 +160,10 @@ function wkit-add-auto -d "Add worktree with optional auto-switch"
     return $exit_code
 end
 
-# Checkout remote branch function with auto-switch capability
-function wkit-checkout -d "Checkout remote branch and create worktree"
+# Checkout existing branch function with auto-switch capability
+function wkit-checkout -d "Checkout existing branch and create worktree"
     if test (count $argv) -eq 0
-        echo "Error: Please specify a remote branch (e.g., origin/feature-branch)" >&2
+        echo "Error: Please specify a branch (local or remote, e.g., feature-branch, origin/feature-branch)" >&2
         return 1
     end
     

--- a/fish/wkit.fish
+++ b/fish/wkit.fish
@@ -26,11 +26,14 @@ function __wkit_complete_worktrees
     wkit list 2>/dev/null | tail -n +3 | awk '{print $2}' | grep -v '^$'
 end
 
-# Tab completion for remote branches
-function __wkit_complete_remote_branches
+# Tab completion for all branches (local and remote)
+function __wkit_complete_all_branches
+    # Local branches
+    git branch 2>/dev/null | sed 's/^[ \t*]*//' | grep -v '^$'
+    # Remote branches  
     git branch -r 2>/dev/null | sed 's/^[ \t]*//' | grep -v '^origin/HEAD' | grep -v '^$'
 end
 
 complete -c wkit -n '__fish_use_subcommand' -a 'list add remove switch checkout' -d 'wkit commands'
 complete -c wkit -n '__fish_seen_subcommand_from switch remove' -a '(__wkit_complete_worktrees)' -d 'Available worktrees'
-complete -c wkit -n '__fish_seen_subcommand_from checkout' -a '(__wkit_complete_remote_branches)' -d 'Available remote branches'
+complete -c wkit -n '__fish_seen_subcommand_from checkout' -a '(__wkit_complete_all_branches)' -d 'Available branches'

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -113,46 +113,67 @@ impl WorktreeManager {
         Ok(())
     }
 
-    pub fn add_worktree_from_remote(&self, remote_branch: &str, local_branch_name: &str, path: Option<&str>) -> Result<()> {
+    pub fn add_worktree_from_existing_branch(&self, source_branch: &str, local_branch_name: &str, path: Option<&str>) -> Result<()> {
         // path should be provided by the caller (using config)
         let target_path = path
             .ok_or_else(|| anyhow::anyhow!("Path must be provided"))?
             .to_string();
-
-        // Check if remote branch exists
-        if !self.remote_branch_exists(remote_branch)? {
-            anyhow::bail!("Remote branch '{}' does not exist", remote_branch);
-        }
 
         // Check if local branch already exists
         if self.branch_exists(local_branch_name)? {
             anyhow::bail!("Local branch '{}' already exists", local_branch_name);
         }
 
-        // Fetch latest changes from remote
-        let remote_parts: Vec<&str> = remote_branch.split('/').collect();
-        if remote_parts.len() >= 2 {
-            let remote_name = remote_parts[0];
+        // Determine if this is a remote or local branch
+        let is_remote_branch = source_branch.contains('/');
+        
+        if is_remote_branch {
+            // Handle remote branch
+            if !self.remote_branch_exists(source_branch)? {
+                anyhow::bail!("Remote branch '{}' does not exist", source_branch);
+            }
+
+            // Fetch latest changes from remote
+            let remote_parts: Vec<&str> = source_branch.split('/').collect();
+            if remote_parts.len() >= 2 {
+                let remote_name = remote_parts[0];
+                let output = Command::new("git")
+                    .args(["fetch", remote_name])
+                    .output()
+                    .context("Failed to fetch from remote")?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    eprintln!("Warning: Failed to fetch from remote: {}", stderr);
+                }
+            }
+
+            // Create worktree with new local branch tracking the remote branch
             let output = Command::new("git")
-                .args(["fetch", remote_name])
+                .args(["worktree", "add", "-b", local_branch_name, &target_path, source_branch])
                 .output()
-                .context("Failed to fetch from remote")?;
+                .context("Failed to execute git worktree add")?;
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                eprintln!("Warning: Failed to fetch from remote: {}", stderr);
+                anyhow::bail!("git worktree add failed: {}", stderr);
             }
-        }
+        } else {
+            // Handle local branch
+            if !self.branch_exists(source_branch)? {
+                anyhow::bail!("Local branch '{}' does not exist", source_branch);
+            }
 
-        // Create worktree with new local branch tracking the remote branch
-        let output = Command::new("git")
-            .args(["worktree", "add", "-b", local_branch_name, &target_path, remote_branch])
-            .output()
-            .context("Failed to execute git worktree add")?;
+            // Create worktree with new local branch based on existing local branch
+            let output = Command::new("git")
+                .args(["worktree", "add", "-b", local_branch_name, &target_path, source_branch])
+                .output()
+                .context("Failed to execute git worktree add")?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git worktree add failed: {}", stderr);
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("git worktree add failed: {}", stderr);
+            }
         }
 
         Ok(())
@@ -446,9 +467,9 @@ bare
     }
 
     #[test]
-    fn test_add_worktree_from_remote_invalid_path() {
+    fn test_add_worktree_from_existing_branch_invalid_path() {
         let manager = WorktreeManager::new();
-        let result = manager.add_worktree_from_remote("origin/feature", "feature", None);
+        let result = manager.add_worktree_from_existing_branch("origin/feature", "feature", None);
         
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Path must be provided"));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -96,16 +96,16 @@ fn test_checkout_help() {
     cmd.args(["checkout", "--help"]);
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("Checkout a remote branch and create worktree"))
-        .stdout(predicates::str::contains("Remote branch name (e.g., origin/feature-branch)"))
+        .stdout(predicates::str::contains("Checkout an existing branch and create worktree"))
+        .stdout(predicates::str::contains("Branch name (local or remote"))
         .stdout(predicates::str::contains("--no-switch"));
 }
 
 #[test]
-fn test_checkout_invalid_remote_branch_format() {
+fn test_checkout_nonexistent_branch() {
     let mut cmd = Command::cargo_bin("wkit").unwrap();
-    cmd.args(["checkout", "invalid-format"]);
+    cmd.args(["checkout", "nonexistent-branch"]);
     cmd.assert()
         .failure()
-        .stderr(predicates::str::contains("Invalid remote branch format"));
+        .stderr(predicates::str::contains("does not exist"));
 }


### PR DESCRIPTION
## Summary

リモートブランチからworktreeを作成する新しい`checkout`サブコマンドを実装し、さらに「既存のブランチからworktreeを作成する」機能に抽象化しました。これによりローカル・リモートブランチの両方に対応し、統一された直感的なAPIを提供します。

- 新しい`wkit checkout <branch> [path]`コマンドを追加
- ローカル・リモートブランチの自動判定とエラーハンドリング
- 既存機能（z integration、file copying、設定システム）との統合
- Fish shell統合（エイリアス、タブ補完、自動切り替え）

## 使用例

```bash
# ローカルブランチから（新しいブランチ名: feature-branch-checkout）
wkit checkout feature-branch

# リモートブランチから（新しいブランチ名: feature-branch）
wkit checkout origin/feature-branch

# カスタムパスを指定
wkit checkout origin/hotfix-123 /custom/path

# 自動切り替えを無効化  
wkit checkout origin/develop --no-switch

# Fish shellでのエイリアス使用
wc origin/feature-branch
```

## 実装内容

### Core機能
- `src/main.rs`: Checkoutサブコマンドの追加と抽象化
- `src/worktree.rs`: `add_worktree_from_existing_branch`メソッドの実装
- ローカル・リモートブランチの自動判定（`/`の有無で判定）
- リモートブランチ存在確認とローカルブランチ衝突チェック
- 自動fetch機能

### ローカルブランチ名の自動生成
- リモートブランチ: `origin/feature-branch` → `feature-branch`
- ローカルブランチ: `feature-branch` → `feature-branch-checkout`

### Fish shell統合
- `fish/functions/wkit.fish`: `wkit-checkout`関数の追加
- `fish/wkit.fish`: `wc`エイリアスとローカル・リモートブランチタブ補完
- 自動ディレクトリ切り替え機能

### テスト
- integration tests: ヘルプとエラーハンドリングのテスト
- unit tests: 新しい抽象化に対応したテスト

## 抽象化による改善点

この抽象化により以下の改善を実現しました：

1. **統一されたインターフェース**: remote/localの違いをユーザーが意識する必要がない
2. **より直感的**: `checkout`は既存のものから作る、`add`は新規作成という明確な使い分け
3. **コードの簡素化**: 単一のメソッドで両方のケースを処理
4. **拡張性**: 将来的に他の種類のブランチ（タグなど）も容易に対応可能

## Test plan

- [x] 既存テストの通過確認
- [x] 新機能のテストケース追加  
- [x] コンパイルエラーの修正
- [x] Fish shell統合の動作確認
- [x] ヘルプコマンドの動作確認
- [x] エラーハンドリングの動作確認
- [x] ローカル・リモートブランチ両方への対応確認

🤖 Generated with [Claude Code](https://claude.ai/code)