### PR TITLE
fix: create new branches from remote default branch instead of current HEAD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ fn cmd_add(manager: &WorktreeManager, branch: &str, path: Option<&str>, no_switc
     let config = Config::load()?;
     let target_path = config.resolve_worktree_path(branch, path);
     
-    manager.add_worktree(branch, Some(&target_path))?;
+    manager.add_worktree(branch, Some(&target_path), &config.main_branch)?;
     println!("✓ Created worktree for branch '{}' at '{}'", branch, target_path);
     
     // Copy configured files to the new worktree

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -83,7 +83,7 @@ impl WorktreeManager {
         Ok(worktrees)
     }
 
-    pub fn add_worktree(&self, branch: &str, path: Option<&str>) -> Result<()> {
+    pub fn add_worktree(&self, branch: &str, path: Option<&str>, main_branch: &str) -> Result<()> {
         // path should be provided by the caller (using config)
         let target_path = path
             .ok_or_else(|| anyhow::anyhow!("Path must be provided"))?
@@ -96,8 +96,9 @@ impl WorktreeManager {
         let branch_exists = self.branch_exists(branch)?;
         
         if !branch_exists {
-            // Use -b flag to create new branch
-            cmd.arg("-b").arg(branch).arg(&target_path);
+            // Use -b flag to create new branch from origin/<main_branch>
+            let base_branch = format!("origin/{}", main_branch);
+            cmd.arg("-b").arg(branch).arg(&target_path).arg(&base_branch);
         } else {
             cmd.arg(&target_path).arg(branch);
         }


### PR DESCRIPTION
## Summary
- Fixed `wkit add` command to create new branches from remote default branch (`origin/main`) instead of current HEAD
- This ensures new branches are always based on the latest main branch, preventing branches from being created off of feature branches

## Changes
- Modified `WorktreeManager::add_worktree` to accept `main_branch` parameter
- Updated git worktree add command to specify `origin/<main_branch>` as base branch when creating new branches
- Updated `cmd_add` function to pass `config.main_branch` to the worktree manager

## Test plan
- [x] All existing tests pass
- [x] New branches are now created from `origin/main` (or configured main branch) instead of current HEAD
- [x] Existing branch checkout functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)