### PR TITLE
Display relative paths from repository root in list and status commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,11 +133,16 @@ fn cmd_list(manager: &WorktreeManager) -> Result<()> {
         return Ok(());
     }
 
+    let repo_root = manager.get_repository_root()?;
+
     println!("{:<30} {:<20} {:<12}", "PATH", "BRANCH", "HEAD");
     println!("{}", "-".repeat(65));
     
     for wt in worktrees {
-        let path_str = wt.path.to_string_lossy();
+        let relative_path = wt.path.strip_prefix(&repo_root)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| wt.path.to_string_lossy().into_owned());
+        
         let head_short = if wt.head.len() > 10 {
             &wt.head[..10]
         } else {
@@ -145,7 +150,7 @@ fn cmd_list(manager: &WorktreeManager) -> Result<()> {
         };
         
         println!("{:<30} {:<20} {:<12}", 
-            path_str, 
+            relative_path, 
             wt.branch, 
             head_short
         );
@@ -300,11 +305,16 @@ fn cmd_status(manager: &WorktreeManager) -> Result<()> {
         return Ok(());
     }
 
+    let repo_root = manager.get_repository_root()?;
+
     println!("{:<30} {:<20} {:<12} {:<15}", "PATH", "BRANCH", "HEAD", "STATUS");
     println!("{}", "-".repeat(80));
     
     for wt in worktrees {
-        let path_str = wt.path.to_string_lossy();
+        let relative_path = wt.path.strip_prefix(&repo_root)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| wt.path.to_string_lossy().into_owned());
+        
         let head_short = if wt.head.len() > 10 {
             &wt.head[..10]
         } else {
@@ -319,7 +329,7 @@ fn cmd_status(manager: &WorktreeManager) -> Result<()> {
         };
         
         println!("{:<30} {:<20} {:<12} {:<15}", 
-            path_str, 
+            relative_path, 
             wt.branch, 
             head_short,
             &status_str

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -29,6 +29,23 @@ impl WorktreeManager {
         Self
     }
 
+    pub fn get_repository_root(&self) -> Result<PathBuf> {
+        let output = Command::new("git")
+            .args(["rev-parse", "--show-toplevel"])
+            .output()
+            .context("Failed to execute git rev-parse")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git rev-parse failed: {}", stderr);
+        }
+
+        let path = String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .to_string();
+        Ok(PathBuf::from(path))
+    }
+
     pub fn list_worktrees(&self) -> Result<Vec<Worktree>> {
         let output = Command::new("git")
             .args(["worktree", "list", "--porcelain"])


### PR DESCRIPTION
## Summary
- Add functionality to display worktree paths as relative paths from the repository root instead of absolute paths
- Makes the output of `wkit list` and `wkit status` commands more concise and readable
- The main worktree (at repository root) is shown as an empty string

## Changes
- Added `get_repository_root()` method to `WorktreeManager` that uses `git rev-parse --show-toplevel`
- Modified `cmd_list()` to convert absolute paths to relative paths before displaying
- Modified `cmd_status()` to convert absolute paths to relative paths for consistency

## Test plan
- [x] Run `wkit list` - verify paths are shown relative to repository root
- [x] Run `wkit status` - verify paths are shown relative to repository root
- [x] Verify main worktree shows as empty string (repository root itself)
- [x] Build passes with `cargo build`

🤖 Generated with [Claude Code](https://claude.ai/code)