### PR TITLE
test: add comprehensive tests for copy files with nested directories

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,3 +124,190 @@ func TestInitLocal(t *testing.T) {
 		t.Errorf("Config file was not created at %v", configPath)
 	}
 }
+
+func TestCopyFilesToWorktreeWithNestedDirectories(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "wkit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	sourceDir := filepath.Join(tmpDir, "source")
+	targetDir := filepath.Join(tmpDir, "target")
+
+	// Create source directory structure
+	err = os.MkdirAll(sourceDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create source dir: %v", err)
+	}
+
+	err = os.MkdirAll(targetDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create target dir: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		config         Config
+		fileStructure  map[string]string // file path -> content
+		expectedCopies []string
+	}{
+		{
+			name: "copy files from nested directories",
+			config: Config{
+				CopyFiles: CopyFiles{
+					Enabled: true,
+					Files:   []string{".envrc", "config.yaml"},
+				},
+			},
+			fileStructure: map[string]string{
+				".envrc":                        "export PATH=/usr/bin",
+				"subdir/.envrc":                 "export PATH=/usr/local/bin",
+				"config/config.yaml":            "database: production",
+				"deep/nested/config.yaml":       "database: test",
+				"config/deep/nested/config.yaml": "database: staging",
+			},
+			expectedCopies: []string{
+				".envrc",
+				"subdir/.envrc",
+				"config/config.yaml",
+				"deep/nested/config.yaml",
+				"config/deep/nested/config.yaml",
+			},
+		},
+		{
+			name: "copy files with specific path patterns",
+			config: Config{
+				CopyFiles: CopyFiles{
+					Enabled: true,
+					Files:   []string{"config/local.yaml", ".env.local"},
+				},
+			},
+			fileStructure: map[string]string{
+				"config/local.yaml":      "env: local",
+				"config/prod.yaml":       "env: prod",
+				"other/config/local.yaml": "env: other",
+				".env.local":             "DEBUG=true",
+				"subdir/.env.local":      "DEBUG=false",
+			},
+			expectedCopies: []string{
+				"config/local.yaml",
+				".env.local",
+				"subdir/.env.local",
+			},
+		},
+		{
+			name: "no files match pattern",
+			config: Config{
+				CopyFiles: CopyFiles{
+					Enabled: true,
+					Files:   []string{"nonexistent.txt"},
+				},
+			},
+			fileStructure: map[string]string{
+				"existing.txt": "content",
+			},
+			expectedCopies: []string{},
+		},
+		{
+			name: "copy disabled",
+			config: Config{
+				CopyFiles: CopyFiles{
+					Enabled: false,
+					Files:   []string{".envrc"},
+				},
+			},
+			fileStructure: map[string]string{
+				".envrc": "export PATH=/usr/bin",
+			},
+			expectedCopies: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up directories for each test
+			os.RemoveAll(sourceDir)
+			os.RemoveAll(targetDir)
+			err = os.MkdirAll(sourceDir, 0755)
+			if err != nil {
+				t.Fatalf("Failed to create source dir: %v", err)
+			}
+			err = os.MkdirAll(targetDir, 0755)
+			if err != nil {
+				t.Fatalf("Failed to create target dir: %v", err)
+			}
+
+			// Create test file structure
+			for filePath, content := range tt.fileStructure {
+				fullPath := filepath.Join(sourceDir, filePath)
+				dir := filepath.Dir(fullPath)
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("Failed to create directory %s: %v", dir, err)
+				}
+				if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+					t.Fatalf("Failed to create file %s: %v", fullPath, err)
+				}
+			}
+
+			// Test CopyFilesToWorktree
+			copiedFiles, err := tt.config.CopyFilesToWorktree(sourceDir, targetDir)
+			if err != nil {
+				t.Fatalf("CopyFilesToWorktree() failed: %v", err)
+			}
+
+			// Check the number of copied files
+			if len(copiedFiles) != len(tt.expectedCopies) {
+				t.Errorf("CopyFilesToWorktree() copied %d files, expected %d", len(copiedFiles), len(tt.expectedCopies))
+				t.Errorf("Copied files: %v", copiedFiles)
+				t.Errorf("Expected files: %v", tt.expectedCopies)
+			}
+
+			// Check if all expected files were copied
+			copiedMap := make(map[string]bool)
+			for _, file := range copiedFiles {
+				copiedMap[file] = true
+			}
+
+			for _, expectedFile := range tt.expectedCopies {
+				if !copiedMap[expectedFile] {
+					t.Errorf("Expected file %s was not copied", expectedFile)
+				}
+
+				// Check if the target file exists and has correct content
+				targetFile := filepath.Join(targetDir, expectedFile)
+				if _, err := os.Stat(targetFile); os.IsNotExist(err) {
+					t.Errorf("Target file %s does not exist", targetFile)
+					continue
+				}
+
+				// Verify content matches
+				expectedContent := tt.fileStructure[expectedFile]
+				actualContent, err := os.ReadFile(targetFile)
+				if err != nil {
+					t.Errorf("Failed to read target file %s: %v", targetFile, err)
+					continue
+				}
+
+				if string(actualContent) != expectedContent {
+					t.Errorf("Target file %s content mismatch. Got: %q, Want: %q", targetFile, string(actualContent), expectedContent)
+				}
+			}
+
+			// Check for unexpected files
+			for _, copiedFile := range copiedFiles {
+				found := false
+				for _, expectedFile := range tt.expectedCopies {
+					if copiedFile == expectedFile {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Unexpected file was copied: %s", copiedFile)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- ネストしたディレクトリでのcopy files機能の包括的なユニットテストを追加
- 複数階層のディレクトリからの同名ファイル検索・コピーの動作を検証
- パス指定とファイル名指定の混在パターンをテスト
- エッジケース（マッチしないファイル、機能無効時）の動作確認

## Test plan
- [x] `go test ./internal/config -v -run TestCopyFilesToWorktreeWithNestedDirectories` でテスト実行
- [x] `go test ./...` で全体のテストが通ることを確認
- [x] 4つのテストケースすべてがパス

🤖 Generated with [Claude Code](https://claude.ai/code)