### PR TITLE
Improve wkit list output format to match git worktree list style

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -39,8 +39,12 @@ func TestCLIIntegration(t *testing.T) {
 		}
 
 		outputStr := string(output)
-		if !strings.Contains(outputStr, "PATH") || !strings.Contains(outputStr, "BRANCH") || !strings.Contains(outputStr, "HEAD") {
+		// New format has header and matches git worktree list format: space-padded with [branch] format
+		if !strings.Contains(outputStr, "PATH") || !strings.Contains(outputStr, "HEAD") || !strings.Contains(outputStr, "BRANCH") {
 			t.Errorf("List output doesn't contain expected headers")
+		}
+		if !strings.Contains(outputStr, "(root)") || !strings.Contains(outputStr, " [") {
+			t.Errorf("List output doesn't contain expected git worktree list format with (root) and [branch]")
 		}
 	})
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -66,12 +66,18 @@ func NewListCmd() *cobra.Command {
 				return encoder.Encode(outputWorktrees)
 			}
 
-			// Default human-readable format
-			fmt.Printf("%-30s %-20s %-12s\n", "PATH", "BRANCH", "HEAD")
-			fmt.Println(strings.Repeat("-", 65))
-
+			// Default human-readable format (space-padded like git worktree list with header)
+			fmt.Printf("%-75s %s %s\n", "PATH", "HEAD", "BRANCH")
+			fmt.Printf("%-75s %s %s\n", strings.Repeat("-", 75), strings.Repeat("-", 7), strings.Repeat("-", 10))
+			
 			for _, wt := range outputWorktrees {
-				fmt.Printf("%-30s %-20s %-12s\n", wt.Path, wt.Branch, wt.HEAD)
+				// Truncate HEAD to 7 characters for display
+				displayHEAD := wt.HEAD
+				if len(displayHEAD) > 7 {
+					displayHEAD = displayHEAD[:7]
+				}
+				// Format: path + padding + hash + space + [branch]
+				fmt.Printf("%-75s %s [%s]\n", wt.Path, displayHEAD, wt.Branch)
 			}
 			return nil
 		},

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -37,9 +37,10 @@ func TestListCommand(t *testing.T) {
 			},
 			repoRoot: "/path/to/repo",
 			expectedOutput: []string{
-				"PATH                           BRANCH               HEAD",
-				"(root)                         main                 1234567890abcdef",
-				".git/.wkit-worktrees/feature-branch feature-branch       abcdef1234567890",
+				"PATH                                                                        HEAD BRANCH",
+				"--------------------------------------------------------------------------- ------- ----------",
+				"(root)                                                                      1234567 [main]",
+				".git/.wkit-worktrees/feature-branch                                        abcdef1 [feature-branch]",
 			},
 		},
 		{
@@ -62,9 +63,10 @@ func TestListCommand(t *testing.T) {
 			},
 			repoRoot: "/path/to/repo",
 			expectedOutput: []string{
-				"PATH                           BRANCH               HEAD",
-				"(root)                         main                 1234567890abcdef",
-				".git/.wkit-worktrees/very-long-feature-branch-name very-long-feature-branch-name abcdef1234567890",
+				"PATH                                                                        HEAD BRANCH",
+				"--------------------------------------------------------------------------- ------- ----------",
+				"(root)                                                                      1234567 [main]",
+				".git/.wkit-worktrees/very-long-feature-branch-name                         abcdef1 [very-long-feature-branch-name]",
 			},
 		},
 	}
@@ -74,22 +76,35 @@ func TestListCommand(t *testing.T) {
 			// This is a unit test for the output formatting logic
 			// We'll verify that the paths are correctly formatted as relative to repo root
 			
-			// For now, we'll just verify the expected structure
+			// Verify the expected space-padded format with header
 			for i, expected := range tt.expectedOutput {
 				if i == 0 {
 					// Header line
-					if !strings.Contains(expected, "PATH") || !strings.Contains(expected, "BRANCH") || !strings.Contains(expected, "HEAD") {
-						t.Errorf("Expected header line to contain PATH, BRANCH, and HEAD")
+					if !strings.Contains(expected, "PATH") || !strings.Contains(expected, "HEAD") || !strings.Contains(expected, "BRANCH") {
+						t.Errorf("Expected header line to contain PATH, HEAD, and BRANCH")
+					}
+				} else if i == 1 {
+					// Separator line
+					if !strings.Contains(expected, "---") {
+						t.Errorf("Expected separator line with dashes")
 					}
 				} else if strings.Contains(expected, "(root)") {
 					// Root worktree should be marked as (root)
-					if !strings.Contains(expected, "main") {
-						t.Errorf("Expected root worktree to be on main branch")
+					if !strings.HasPrefix(expected, "(root)") {
+						t.Errorf("Expected root worktree to start with '(root)', got: %s", expected)
+					}
+					if !strings.Contains(expected, "[main]") {
+						t.Errorf("Expected root worktree to contain '[main]', got: %s", expected)
 					}
 				} else {
 					// Other worktrees should show relative path from repo root
 					if !strings.HasPrefix(expected, ".git/.wkit-worktrees/") {
 						t.Errorf("Expected non-root worktree path to start with .git/.wkit-worktrees/, got: %s", expected)
+					}
+					
+					// Should have the git worktree list format: path + spaces + hash + space + [branch]
+					if !strings.Contains(expected, " [") || !strings.HasSuffix(expected, "]") {
+						t.Errorf("Expected format 'path hash [branch]', got: %s", expected)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Enhanced `wkit list` output format to align with `git worktree list` styling while maintaining wkit's unique advantages
- Added user-friendly header row that `git worktree list` lacks
- Improved readability with space-padded columns and 7-character commit hashes
- Preserved relative path display and JSON format compatibility

## Changes Made
- **Format Alignment**: Changed from fixed-width columns to space-padded format matching `git worktree list`
- **Commit Hash Display**: Truncated to 7 characters for human-readable output (full hashes preserved in JSON)
- **Branch Format**: Added `[branch-name]` bracket notation to match git convention  
- **Enhanced UX**: Added header row with `PATH`, `HEAD`, `BRANCH` columns for clarity
- **Maintained Advantages**: Kept relative path display (`(root)`, `.git/.wkit-worktrees/...`) as wkit's unique feature

## Before
```
PATH                           BRANCH               HEAD        
-----------------------------------------------------------------
(root)                         main                 451087b4289e2efe34769c710a14323385623fa4
.git/.wkit-worktrees/feature   feature              abcdef1234567890abcdef1234567890abcdef12
```

## After  
```
PATH                                                                        HEAD BRANCH
--------------------------------------------------------------------------- ------- ----------
(root)                                                                      451087b [main]
.git/.wkit-worktrees/feature                                                abcdef1 [feature]
```

## Test Plan
- [x] All existing unit tests updated and passing
- [x] Integration tests updated to verify new format
- [x] JSON output format unchanged for API compatibility
- [x] Manual testing confirms improved readability
- [x] Verified format consistency across different terminal widths

🤖 Generated with [Claude Code](https://claude.ai/code)