### PR TITLE
refactor: improve wkit list table formatting with text/tabwriter

### DIFF
--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"wkit/internal/worktree"
@@ -66,9 +66,13 @@ func NewListCmd() *cobra.Command {
 				return encoder.Encode(outputWorktrees)
 			}
 
-			// Default human-readable format (space-padded like git worktree list with header)
-			fmt.Printf("%-75s %s %s\n", "PATH", "HEAD", "BRANCH")
-			fmt.Printf("%-75s %s %s\n", strings.Repeat("-", 75), strings.Repeat("-", 7), strings.Repeat("-", 10))
+			// Default human-readable format using tabwriter for proper alignment
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			defer w.Flush()
+
+			// Header
+			fmt.Fprintln(w, "PATH\tHEAD\tBRANCH")
+			fmt.Fprintln(w, "----\t----\t------")
 			
 			for _, wt := range outputWorktrees {
 				// Truncate HEAD to 7 characters for display
@@ -76,8 +80,8 @@ func NewListCmd() *cobra.Command {
 				if len(displayHEAD) > 7 {
 					displayHEAD = displayHEAD[:7]
 				}
-				// Format: path + padding + hash + space + [branch]
-				fmt.Printf("%-75s %s [%s]\n", wt.Path, displayHEAD, wt.Branch)
+				// Format with tabs for proper alignment
+				fmt.Fprintf(w, "%s\t%s\t%s\n", wt.Path, displayHEAD, wt.Branch)
 			}
 			return nil
 		},

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -37,10 +37,10 @@ func TestListCommand(t *testing.T) {
 			},
 			repoRoot: "/path/to/repo",
 			expectedOutput: []string{
-				"PATH                                                                        HEAD BRANCH",
-				"--------------------------------------------------------------------------- ------- ----------",
-				"(root)                                                                      1234567 [main]",
-				".git/.wkit-worktrees/feature-branch                                        abcdef1 [feature-branch]",
+				"PATH\tHEAD\tBRANCH",
+				"----\t----\t------",
+				"(root)\t1234567\tmain",
+				".git/.wkit-worktrees/feature-branch\tabcdef1\tfeature-branch",
 			},
 		},
 		{
@@ -63,10 +63,10 @@ func TestListCommand(t *testing.T) {
 			},
 			repoRoot: "/path/to/repo",
 			expectedOutput: []string{
-				"PATH                                                                        HEAD BRANCH",
-				"--------------------------------------------------------------------------- ------- ----------",
-				"(root)                                                                      1234567 [main]",
-				".git/.wkit-worktrees/very-long-feature-branch-name                         abcdef1 [very-long-feature-branch-name]",
+				"PATH\tHEAD\tBRANCH",
+				"----\t----\t------",
+				"(root)\t1234567\tmain",
+				".git/.wkit-worktrees/very-long-feature-branch-name\tabcdef1\tvery-long-feature-branch-name",
 			},
 		},
 	}
@@ -93,8 +93,8 @@ func TestListCommand(t *testing.T) {
 					if !strings.HasPrefix(expected, "(root)") {
 						t.Errorf("Expected root worktree to start with '(root)', got: %s", expected)
 					}
-					if !strings.Contains(expected, "[main]") {
-						t.Errorf("Expected root worktree to contain '[main]', got: %s", expected)
+					if !strings.Contains(expected, "\tmain") {
+						t.Errorf("Expected root worktree to contain tab-separated 'main', got: %s", expected)
 					}
 				} else {
 					// Other worktrees should show relative path from repo root
@@ -102,9 +102,9 @@ func TestListCommand(t *testing.T) {
 						t.Errorf("Expected non-root worktree path to start with .git/.wkit-worktrees/, got: %s", expected)
 					}
 					
-					// Should have the git worktree list format: path + spaces + hash + space + [branch]
-					if !strings.Contains(expected, " [") || !strings.HasSuffix(expected, "]") {
-						t.Errorf("Expected format 'path hash [branch]', got: %s", expected)
+					// Should have the tab-separated format: path + tab + hash + tab + branch
+					if strings.Count(expected, "\t") != 2 {
+						t.Errorf("Expected format 'path\\thash\\tbranch' with 2 tabs, got: %s", expected)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- wkit listコマンドの表示形式をtext/tabwriterを使用して改善
- 固定幅75文字のPATH列による見栄えの問題を解決
- ヘッダーとデータの整列問題を修正

## Changes
- Go標準ライブラリ`text/tabwriter`を採用して動的列幅調整を実現
- `[branch]`から`branch`に変更してより読みやすい表示に
- テストケースを新しい出力形式に合わせて更新

## Before
```
PATH                                                                        HEAD BRANCH
--------------------------------------------------------------------------- ------- ----------
(root)                                                                      f56a22b [main]
.git/.wkit-worktrees/refactor/list-width                                   f56a22b [refactor/list-width]
```

## After
```
PATH                                      HEAD     BRANCH
----                                      ----     ------
(root)                                    f56a22b  main
.git/.wkit-worktrees/refactor/list-width  f56a22b  refactor/list-width
```

## Test plan
- [x] 単体テストが通ること
- [x] 実際の出力で列が正しく整列されること
- [x] JSON出力には影響がないこと
- [x] 長いパス名でも適切に表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)