### PR TITLE
feat: migrate configuration format from TOML to YAML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Core Architecture
 
 - **Go CLI Core**: Main binary built with `cobra` for command parsing
-- **Configuration System**: TOML-based configuration with local (`.wkit.toml`) and global (`~/.config/wkit/config.toml`) precedence
+- **Configuration System**: YAML-based configuration with local (`.wkit.yaml`) and global (`~/.config/wkit/config.yaml`) precedence
 - **Worktree Management**: Git worktree wrapper with enhanced functionality in `internal/worktree/manager.go`
 - **Structured Output**: Supports JSON output format for easy scripting and integration (e.g., `wkit list --format=json`)
 - **Fish Integration Examples**: Example functions and configurations in `examples/fish/` directory
@@ -33,7 +33,7 @@ cp examples/fish/functions/*.fish ~/.config/fish/functions/
 ## Module Structure
 
 - `main.go`: CLI command definitions and handlers using cobra
-- `internal/config/config.go`: Configuration management with TOML serialization/deserialization
+- `internal/config/config.go`: Configuration management with YAML serialization/deserialization
 - `internal/worktree/manager.go`: Core Git worktree operations and management
 - `internal/cmd/`: Command implementations with JSON output support
 - `examples/fish/`: Fish shell integration examples (functions, completions, aliases)
@@ -42,8 +42,8 @@ cp examples/fish/functions/*.fish ~/.config/fish/functions/
 
 Uses a hierarchical configuration system:
 1. Command-line arguments (highest priority)
-2. Local `.wkit.toml` in current directory
-3. Global `~/.config/wkit/config.toml`
+2. Local `.wkit.yaml` in current directory
+3. Global `~/.config/wkit/config.yaml`
 4. Built-in defaults (lowest priority)
 
 Configuration keys: `wkit_root`, `auto_cleanup`, `default_sync_strategy`, `main_branch`, `copy_files`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A CLI tool for convenient Git worktree management.
 ## Features
 
 - **Worktree management** - Create, list, remove, and switch between Git worktrees
-- **Flexible configuration** - Local (`.wkit.toml`) and global (`~/.config/wkit/config.toml`) configuration with XDG support
+- **Flexible configuration** - Local (`.wkit.yaml`) and global (`~/.config/wkit/config.yaml`) configuration with XDG support
 - **Batch operations** - Clean up multiple worktrees efficiently
 - **Sync with main branch** - Keep worktrees up-to-date with merge or rebase
 - **Z-style navigation** - Frecency-based worktree jumping
@@ -107,37 +107,40 @@ See [examples/fish/](examples/fish/) for shell integration examples including:
 ## Configuration
 
 Configuration files:
-- Local: `.wkit.toml` (project-specific)
-- Global: `~/.config/wkit/config.toml` (or `$XDG_CONFIG_HOME/wkit/config.toml`)
+- Local: `.wkit.yaml` (project-specific)
+- Global: `~/.config/wkit/config.yaml` (or `$XDG_CONFIG_HOME/wkit/config.yaml`)
 
 ### Options
 
-```toml
+```yaml
 # Default path for new worktrees
-wkit_root = ".git/.wkit-worktrees"
+wkit_root: ".git/.wkit-worktrees"
 
 # Automatically clean up deleted branches
-auto_cleanup = false
+auto_cleanup: false
 
 # Enable z integration
-z_integration = true
+z_integration: true
 
 # Default sync strategy (merge or rebase)
-default_sync_strategy = "merge"
+default_sync_strategy: "merge"
 
 # Main branch name
-main_branch = "main"
+main_branch: "main"
 
 # Copy files to new worktrees
-[copy_files]
-enabled = false
-files = [".envrc", ".env.local", "compose.override.yaml"]
+copy_files:
+  enabled: false
+  files:
+    - ".envrc"
+    - ".env.local"
+    - "compose.override.yaml"
 ```
 
 ### Precedence
 
 1. Command-line arguments
-2. Local `.wkit.toml`
+2. Local `.wkit.yaml`
 3. Global config
 4. Built-in defaults
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -105,7 +105,7 @@ func NewConfigInitCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create local config file: %w", err)
 			}
-			fmt.Println("✓ Created local configuration file: .wkit.toml")
+			fmt.Println("✓ Created local configuration file: .wkit.yaml")
 			return nil
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type CopyFiles struct {
 func Load() (*Config, error) {
 	v := viper.New()
 	v.SetConfigName("config") // global config file name
-	v.SetConfigType("toml")
+	v.SetConfigType("yaml")
 	if home, err := os.UserHomeDir(); err == nil {
 		v.AddConfigPath(filepath.Join(home, ".config", "wkit")) // global config path
 	}
@@ -53,7 +53,7 @@ func Load() (*Config, error) {
 	// Read local config (if exists) and merge
 	localV := viper.New()
 	localV.SetConfigName(".wkit") // local config file name
-	localV.SetConfigType("toml")
+	localV.SetConfigType("yaml")
 	localV.AddConfigPath(".")
 
 	if err := localV.ReadInConfig(); err == nil {
@@ -80,7 +80,7 @@ func Load() (*Config, error) {
 func SaveGlobal(cfg *Config) error {
 	v := viper.New()
 	v.SetConfigName("config")
-	v.SetConfigType("toml")
+	v.SetConfigType("yaml")
 	if home, err := os.UserHomeDir(); err == nil {
 		v.AddConfigPath(filepath.Join(home, ".config", "wkit"))
 	} else {
@@ -102,7 +102,7 @@ func SaveGlobal(cfg *Config) error {
 	v.Set("copy_files.enabled", cfg.CopyFiles.Enabled)
 	v.Set("copy_files.files", cfg.CopyFiles.Files)
 
-	configPath := filepath.Join(configDir, "config.toml")
+	configPath := filepath.Join(configDir, "config.yaml")
 	if err := v.WriteConfigAs(configPath); err != nil {
 		return fmt.Errorf("failed to write global config file: %w", err)
 	}
@@ -110,11 +110,11 @@ func SaveGlobal(cfg *Config) error {
 	return nil
 }
 
-// InitLocal creates a local .wkit.toml file with default values
+// InitLocal creates a local .wkit.yaml file with default values
 func InitLocal() error {
 	v := viper.New()
 	v.SetConfigName(".wkit")
-	v.SetConfigType("toml")
+	v.SetConfigType("yaml")
 	v.AddConfigPath(".")
 
 	// Set default values
@@ -126,7 +126,7 @@ func InitLocal() error {
 	v.SetDefault("copy_files.enabled", false)
 	v.SetDefault("copy_files.files", []string{".envrc", "compose.override.yaml", ".env.local", "config/local.yaml"})
 
-	if err := v.SafeWriteConfigAs(".wkit.toml"); err != nil {
+	if err := v.SafeWriteConfigAs(".wkit.yaml"); err != nil {
 		return fmt.Errorf("failed to create local config file: %w", err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,7 +132,7 @@ func TestInitLocal(t *testing.T) {
 	}
 
 	// Check if the file was created
-	configPath := filepath.Join(tmpDir, ".wkit.toml")
+	configPath := filepath.Join(tmpDir, ".wkit.yaml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		t.Errorf("Config file was not created at %v", configPath)
 	}


### PR DESCRIPTION
## Summary

- 設定ファイル形式をTOMLからYAMLに変更
- 設定ファイル名を`.wkit.toml`から`.wkit.yaml`に変更
- グローバル設定ファイル名を`config.toml`から`config.yaml`に変更
- ドキュメントとテストを更新

## Test plan

- [x] `wkit config init`でYAMLファイルが作成されることを確認
- [x] `wkit config show`でYAML設定が正しく読み込まれることを確認
- [x] `wkit config set`でYAML設定が正しく更新されることを確認
- [x] 設定関連のユニットテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)